### PR TITLE
docs: add docker guide, and improve index

### DIFF
--- a/index.md
+++ b/index.md
@@ -13,28 +13,33 @@ Mainsail makes Klipper more accessible by adding a lightweight, responsive web u
 [GitHub](https://github.com/mainsail-crew/mainsail){: .btn}{:target="_blank"}
 [Release Notes](https://github.com/mainsail-crew/mainsail/releases){: .btn}{:target="_blank"}
 
+Mainsail is also available in remote mode on [http://my.mainsail.xyz](http://my.mainsail.xyz). Find
+out [more](/setup#mymainsailxyz).
+
 ## Screenshots
 ![Dashboard](assets/img/screenshot.png)
 ![Features](assets/img/features.png)
 
-## Features 
-- Responsive web interface, optimized for desktops, tablets and mobile devices
-- Supports multiple 3D printers (Printer Farm)
-- Localization (i18n)
-- File Manager (G-Code and config files)
-- File Editor (G-Code and config files)
-- Print History and Statistics
-- Job Queue
-- Temperature Presets (with custom gcode)
-- Bed Mesh visualisation
-- G-Code Viewer
-- Multi-Webcam support
-- Timelapse integration
-- Control power devices such as relays, TPLink and Tasmota devices, and more
-- Powerful Macro-Management
-- Configurable dashboard
-- Customizable user interface including logos, backgrounds, and custom CSS
-- Exclude objects (not yet officially supported by Klipper)
+## Features
+- **Responsive Web Interface:** _Optimized for desktops, tablets and mobile devices_
+- **Printer Farm:** _Supports multiple 3D printers_
+- **[Localization](/features/localization):** _Choose between 12 different languages_
+- **File Manager:** _Delete, rename and upload your G-Code and config files_
+- **File Editor:** _Edit G-Code and config files with syntax highlighting in your browser_
+- **[Print History](/features/history):** _See your previous prints and their status_
+- **[Statistics](/features/history):** _View how much time your printer has been in use and the number of jobs that have succeeded or failed_
+- **Job Queue:** _Queue multiple jobs and add them directly from your slicer_
+- **[Temperature Presets](/features/presets):** _Manage different temperature presets for easy preheating_
+- **[Bed Mesh Visualisation](/features/bedmesh):** _View your bed using a 3D mesh graph_
+- **G-Code Viewer:** _View a 3D render of your print and follow the progress_
+- **Multi-Webcam Support:** _View and record from different angles with multiple webcams_
+- **Timelapse Integration:** _Automatically record a timelapse of your print using [moonraker-timelapse](https://github.com/mainsail-crew/moonraker-timelapse)_
+- **Power Control:** _Control power devices such as relays, TP-Link and Tasmota devices, and more_
+- **Powerful Macro-Management:** _Manage your macros on a micro level_
+- **[Configurable Dashboard](/features/dashboard-organisation):** _Create your own personal dashboard_
+- **[Theming Support](/features/theming/):** _Customizable user interface including logos, backgrounds, and custom CSS_
+- **[Additional Sensors](/quicktips/additional-sensors):** _Add extra sensors to the temperature graph_
+- **Exclude Objects:** _Exclude parts of your print <sup>(not officially supported by Klipper yet)</sup>_
 
 ## Help and Support
 Do you need help or just want to talk? Join our active community on Discord. 

--- a/index.md
+++ b/index.md
@@ -37,7 +37,7 @@ out [more](/setup#mymainsailxyz).
 - **Power Control:** _Control power devices such as relays, TP-Link and Tasmota devices, and more_
 - **Powerful Macro-Management:** _Manage your macros on a micro level_
 - **[Configurable Dashboard](/features/dashboard-organisation):** _Create your own personal dashboard_
-- **[Theming Support](/features/theming/):** _Customizable user interface including logos, backgrounds, and custom CSS_
+- **[Theming Support](/features/theming):** _Customizable user interface including logos, backgrounds, and custom CSS_
 - **[Additional Sensors](/quicktips/additional-sensors):** _Add extra sensors to the temperature graph_
 - **Exclude Objects:** _Exclude parts of your print <sup>(not officially supported by Klipper yet)</sup>_
 

--- a/setup-guide/docker.md
+++ b/setup-guide/docker.md
@@ -1,0 +1,55 @@
+---
+layout: default
+title: Docker
+parent: Setup Guides
+nav_order: 3
+has_children: false
+permalink: /setup/docker
+---
+# Installing Mainsail using Docker
+
+It's possible to run Mainsail in Docker with our pre-built images. These images are running Nginx with Mainsail.
+Our images are hosted on the Github Package Registry. You can find more details [here](https://github.com/mainsail-crew/mainsail/pkgs/container/mainsail).
+
+The image can be pulled using:
+
+```sh
+$ docker pull ghcr.io/mainsail-crew/mainsail
+```
+
+## Configuration for the Docker image
+By default the image will connect to `localhost:7125`. If Moonraker is not running on that address, you can configure Mainsail to behave differently using a config file. You can easily mount this file in your container.
+
+First make sure that you have a `config.json` file configured. This is a `json` file that can look like this:
+
+```json
+{
+  "remoteMode": true
+}
+```
+
+You can set Mainsail in remote mode using the `remoteMode` option. That way you can manage your printers in the UI.
+
+## Running with the custom configuration
+
+After creating the `config.json` file the container is ready to run. Make sure you're executing the command in the same directory as your `config.json`.
+Running the following command will launch Mainsail on `http://localhost:8080`:
+
+```sh
+$ docker run \
+  --name mainsail \
+  -v "$(pwd)/config.json:/usr/share/nginx/html/config.json" \
+  -p "8080:80" \
+  ghcr.io/mainsail-crew/mainsail 
+```
+
+### Specifically for Windows, you can run:
+```sh
+docker run --name mainsail -v "%cd%//config.json:/usr/share/nginx/html/config.json" -p "8080:80" ghcr.io/mainsail-crew/mainsail 
+```
+
+## Updating the container
+
+`docker run` will always run the image that's locally available. 
+To get the latest image locally available, you'll just need to pull the image again. 
+After that, the `docker run` command will use the newest version.

--- a/setup-guide/docker.md
+++ b/setup-guide/docker.md
@@ -8,7 +8,7 @@ permalink: /setup/docker
 ---
 # Installing Mainsail using Docker
 
-It's possible to run Mainsail in Docker with our pre-built images. These images are running Nginx with Mainsail.
+It's possible to run Mainsail in Docker with our pre-built images. These images are running NGINX with Mainsail.
 Our images are hosted on the Github Package Registry. You can find more details [here](https://github.com/mainsail-crew/mainsail/pkgs/container/mainsail).
 
 The image can be pulled using:
@@ -18,7 +18,7 @@ $ docker pull ghcr.io/mainsail-crew/mainsail
 ```
 
 ## Configuration for the Docker image
-By default the image will connect to `localhost:7125`. If Moonraker is not running on that address, you can configure Mainsail to behave differently using a config file. You can easily mount this file in your container.
+By default the image will connect to `localhost:7125`. If Moonraker is not running on that address, you can configure Mainsail to behave differently using a config file. You can mount this file in your container.
 
 First make sure that you have a `config.json` file configured. This is a `json` file that can look like this:
 


### PR DESCRIPTION
This adds a guide for installing Mainsail through Docker, and improves the `index.md` just like the `README.md` from the repository.﻿
