### PR TITLE
fix(update-manager.md): fix page title formatting

### DIFF
--- a/features/update-manager.md
+++ b/features/update-manager.md
@@ -9,8 +9,9 @@ redirect_from: /quicktips/update-manager
 description: >-
   Perform updates of Mainsail, Klipper, Moonraker and your system from within Mainsail.
 ---
- # {{ page.title }}
+# {{ page.title }}
 {{ page.description }}
+{: .fs-5 }
 
 ## Moonraker.conf
 


### PR DESCRIPTION
## Before:
![22-06-11_08-40-44_chrome](https://user-images.githubusercontent.com/31533186/173178142-96e53461-c018-42e1-a9bf-498a9d99028d.png)

## After:
![22-06-11_09-24-04_chrome](https://user-images.githubusercontent.com/31533186/173178145-c53a2d87-6045-4363-ad6e-fb98b9a6aec9.png)


Signed-off-by: Dominik Willner <th33xitus@gmail.com>