### PR TITLE
fix(mainsailos): clarify first-boot guide (find update manager)

### DIFF
--- a/docs/mainsailos/getting-started/first-boot.md
+++ b/docs/mainsailos/getting-started/first-boot.md
@@ -38,7 +38,7 @@ may need to replace `mainsailos` with the hostname you chose while flashing the 
 ## Update Manager
 
 To find the Update Manager, select **Machine** in the sidebar navigation. The Update Manager is displayed at the
-right-bottom of the Machine page.
+bottom-right of the Machine page.
 
 When you open the Update Manager for the first time, it may show that some components have updates available.
 

--- a/docs/mainsailos/getting-started/first-boot.md
+++ b/docs/mainsailos/getting-started/first-boot.md
@@ -37,6 +37,9 @@ may need to replace `mainsailos` with the hostname you chose while flashing the 
 
 ## Update Manager
 
+To find the Update Manager, select **Machine** in the sidebar navigation. The Update Manager is displayed at the
+right-bottom of the Machine page.
+
 When you open the Update Manager for the first time, it may show that some components have updates available.
 
 <figure markdown="span">


### PR DESCRIPTION
This PR improve the first boot guide to add a short guide to find the update manager.

This PR fixes #43 